### PR TITLE
Refine SwissChat texts and policies

### DIFF
--- a/agb.html
+++ b/agb.html
@@ -85,7 +85,7 @@
 
       <section aria-labelledby="credits">
         <h2 id="credits"><span class="num" aria-hidden="true">3</span> Credits & Bezahlung</h2>
-        <p>Die Nutzung erfolgt über ein Credit-System. Guthaben kann aufgeladen werden und wird bei Anfragen je nach Token- bzw. Sprachnachrichtenverbrauch abgezogen.</p>
+        <p>Die Nutzung erfolgt über ein reines Prepaid-Credit-System. Guthaben kann aufgeladen werden und wird bei Anfragen je nach Token- bzw. Sprachnachrichtenverbrauch abgezogen. Bei einer Kontolöschung verfallen verbleibende Credits unwiederbringlich.</p>
       </section>
 
       <section aria-labelledby="limits">
@@ -96,18 +96,18 @@
       <section aria-labelledby="vertrag">
         <h2 id="vertrag"><span class="num" aria-hidden="true">5</span> Vertragsabschluss, Laufzeit & Kündigung</h2>
         <ul>
-          <li>Der Vertrag kommt mit Abschluss der Zahlung bzw. Bestätigung im Checkout zustande.</li>
-          <li>Bei Abonnements läuft der Vertrag auf unbestimmte Zeit mit der gewählten Abrechnungsperiode und kann jederzeit mit Wirkung zum Ende der aktuellen Periode gekündigt werden.</li>
-          <li>Einmalprodukte enden mit vollständiger Leistungserbringung.</li>
+          <li>Der Vertrag kommt mit dem Kauf von Credits zustande.</li>
+          <li>Der Dienst ist ausschließlich prepaid und läuft, solange Guthaben vorhanden ist.</li>
+          <li>Bei Löschung des Kontos verfallen verbleibende Credits endgültig.</li>
         </ul>
       </section>
 
       <section aria-labelledby="widerruf">
         <h2 id="widerruf"><span class="num" aria-hidden="true">6</span> Rückerstattungen & Widerruf</h2>
         <ul>
-          <li>Für digitale Leistungen besteht in der Schweiz kein generelles gesetzliches Widerrufsrecht. Eine Rückerstattung bereits erbrachter/angefangener Leistungsperioden ist ausgeschlossen.</li>
+          <li>Für digitale Leistungen besteht in der Schweiz kein generelles gesetzliches Widerrufsrecht. Eine Rückerstattung bereits erbrachter/angefangener Leistungsperioden oder nicht genutzter Prepaid-Credits ist ausgeschlossen.</li>
           <li><strong>Fehl- oder Doppelabbuchungen</strong> werden nach Prüfung vollständig erstattet.</li>
-          <li>Bei <strong>anhaltenden, vollständigen Dienstausfällen (&gt; 24 h)</strong> gewähren wir eine anteilige Gutschrift auf die nächste Periode.</li>
+          <li>Bei <strong>anhaltenden, vollständigen Dienstausfällen (&gt; 24 h)</strong> gewähren wir eine anteilige Gutschrift auf dein Guthaben.</li>
           <li>Gesetzlich zwingende Rechte bleiben unberührt.</li>
         </ul>
       </section>
@@ -138,7 +138,7 @@
 
       <section aria-labelledby="aenderungen">
         <h2 id="aenderungen"><span class="num" aria-hidden="true">11</span> Änderungen der Leistungen/AGB</h2>
-        <p>Wir können Leistungen weiterentwickeln und AGB anpassen. Über wesentliche Änderungen informieren wir in geeigneter Form. Die fortgesetzte Nutzung gilt als Zustimmung; bei Widerspruch kannst du zum Periodenende kündigen.</p>
+        <p>Wir können Leistungen weiterentwickeln und AGB anpassen. Über wesentliche Änderungen informieren wir in geeigneter Form. Die fortgesetzte Nutzung gilt als Zustimmung; bei Widerspruch kannst du die Nutzung einstellen.</p>
       </section>
 
       <section aria-labelledby="haftung">

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -78,14 +78,14 @@
         <h2 id="kurz"><span class="num" aria-hidden="true">1</span> In Kürze (TL;DR)</h2>
         <div class="grid">
           <div class="kachel">
-            <p><strong>Was wir tun:</strong><br>Wir verarbeiten deine WhatsApp-Nachrichten (Text/Audio), um dir Antworten zu geben. Sprachdaten werden von einem LLM transkribiert/verarbeitet und danach gelöscht. Der Chat-Kontext wird nur <strong>max. 10 Minuten</strong> im RAM gehalten, damit das LLM sinnvoll antworten kann.</p>
+            <p><strong>Was wir tun:</strong><br>Wir verarbeiten deine WhatsApp-Nachrichten (Text/Audio/Bilder), um dir Antworten zu geben. Sprach- und Bilddaten werden von einem LLM transkribiert bzw. analysiert und danach gelöscht. Der Chat-Kontext wird nur <strong>max. 10 Minuten</strong> im RAM gehalten, damit das LLM sinnvoll antworten kann.</p>
           </div>
           <div class="kachel">
             <p><strong>Was wir nicht tun:</strong><br>Keine dauerhafte Speicherung von Nachrichteninhalten, kein Verkauf von Daten, keine Weitergabe an Werbenetzwerke, keine Profilbildung.</p>
           </div>
         </div>
         <div class="highlight">
-          <p><span class="badge">Optional</span> Wenn du die Websuche aktivierst, stellen wir bei Bedarf über die <strong>Serper-API</strong> nur eine <em>Sachfrage</em> (z. B. „Wie ist das Wetter morgen in Zürich?“). <strong>Es werden keine Nutzeridentifikatoren</strong> wie Telefonnummer oder Name mitgeschickt.</p>
+          <p><span class="badge">Optional</span> Wenn du die Websuche aktivierst, stellen wir bei Bedarf über die <strong>Brave Search API und/oder Serper</strong> nur eine <em>Sachfrage</em> (z. B. „Wie ist das Wetter morgen in Zürich?“). <strong>Es werden keine Nutzeridentifikatoren</strong> wie Telefonnummer oder Name mitgeschickt.</p>
         </div>
       </section>
 
@@ -104,11 +104,11 @@
         <h2 id="daten"><span class="num" aria-hidden="true">3</span> Welche Daten wir verarbeiten und warum</h2>
 
         <details open>
-          <summary><strong>Nachrichteninhalte (Text & Audio)</strong></summary>
+          <summary><strong>Nachrichteninhalte (Text, Audio & Bilder)</strong></summary>
           <ul>
-            <li><strong>Zweck:</strong> Antworten erstellen; bei Audio Transkription (inkl. Dialekt) via LLM.</li>
-            <li><strong>Speicherdauer:</strong> <em>Chat-Kontext max. 10 Minuten (RAM-only)</em>; Audioclips nach der Verarbeitung gelöscht.</li>
-            <li><strong>Hinweis LLM:</strong> Sprachdaten werden nur zur Transkription/Antwort genutzt und im Anschluss verworfen.</li>
+            <li><strong>Zweck:</strong> Antworten erstellen; Audio und Bilder werden via LLM transkribiert bzw. analysiert.</li>
+            <li><strong>Speicherdauer:</strong> <em>Chat-Kontext max. 10 Minuten (RAM-only)</em>; Audio- und Bilddateien nach der Verarbeitung gelöscht.</li>
+            <li><strong>Hinweis LLM:</strong> Sprach- und Bilddaten werden nur zur Transkription bzw. Analyse/Antwort genutzt und im Anschluss verworfen.</li>
           </ul>
         </details>
 
@@ -177,7 +177,8 @@
             <summary><strong>Gelöschte Nutzer:innen</strong></summary>
             <ul>
               <li><strong>Zweck:</strong> Nachweispflichten und Reaktivierung.</li>
-              <li><strong>Speicherdauer:</strong> Einträge in <code>deleted_users.jsonl</code> bleiben dauerhaft.</li>
+              <li><strong>Gespeichert:</strong> Blockierungsstatus und Nutzungsstatistiken unter verschlüsselter Nummer.</li>
+              <li><strong>Speicherdauer:</strong> dauerhaft.</li>
             </ul>
           </details>
 
@@ -185,7 +186,7 @@
             <summary><strong>Temporäre Mediendateien</strong></summary>
             <ul>
               <li><strong>Zweck:</strong> Transkription bzw. Analyse von Audio und Bildern.</li>
-              <li><strong>Speicherdauer:</strong> nur kurzfristig im Temp-Verzeichnis, danach gelöscht.</li>
+              <li><strong>Speicherdauer:</strong> nur kurzfristig gespeichert, danach gelöscht.</li>
             </ul>
           </details>
         </section>
@@ -195,8 +196,8 @@
         <h2 id="fluss"><span class="num" aria-hidden="true">4</span> So läuft die Verarbeitung ab</h2>
         <ol>
           <li><strong>WhatsApp → SwissChat:</strong> Deine Nachricht kommt via WhatsApp/Meta technisch bedingt bei uns an.</li>
-          <li><strong>SwissChat verarbeitet:</strong> Text wird direkt beantwortet; Audio wird kurz durch ein LLM transkribiert/analysiert. Audio wird danach gelöscht; Chat-Kontext bleibt max. 10 Min. im RAM.</li>
-          <li><strong>Antwort an dich:</strong> Wir schicken die Antwort über WhatsApp zurück. (Optional: Bei aktivierter Websuche stellen wir eine generische Frage über die Serper-API – ohne Nutzerinfos.)</li>
+          <li><strong>SwissChat verarbeitet:</strong> Text wird direkt beantwortet; Audio und Bilder werden kurz durch ein LLM transkribiert bzw. analysiert. Medien werden danach gelöscht; Chat-Kontext bleibt max. 10 Min. im RAM.</li>
+          <li><strong>Antwort an dich:</strong> Wir schicken die Antwort über WhatsApp zurück. (Optional: Bei aktivierter Websuche stellen wir eine generische Frage über die Brave Search API oder Serper – ohne Nutzerinfos.)</li>
         </ol>
       </section>
 
@@ -208,11 +209,11 @@
             <li><strong>Weitergabe:</strong> keine Weitergabe personenbezogener Daten an Dritte, ausser:
               <ul>
                 <li>an WhatsApp/Meta für die reine Nachrichtenübertragung (technisch erforderlich),</li>
-                <li>an KI- und Sprachdienste wie AlpineAI/OpenAI zur Beantwortung deiner Anfragen,</li>
+                <li>an KI- und Sprachdienste wie AlpineAI zur Beantwortung deiner Anfragen,</li>
                 <li>falls gesetzlich vorgeschrieben.</li>
               </ul>
             </li>
-            <li><strong>Websuche (Opt-in):</strong> Anfrage über einen externen Suchdienst (z. B. Serper/Brave) ohne Nutzeridentifikatoren.</li>
+            <li><strong>Websuche (Opt-in):</strong> Anfrage über einen externen Suchdienst (z. B. Brave Search API und/oder Serper) ohne Nutzeridentifikatoren.</li>
           </ul>
         </section>
 

--- a/impressum.html
+++ b/impressum.html
@@ -76,8 +76,7 @@
             <span itemprop="postalCode">8840</span> <span itemprop="addressLocality">Einsiedeln</span><br>
             <span itemprop="addressCountry">Schweiz</span></p>
           </div>
-          <p>E‑Mail: <a href="mailto:swisschat@icloud.com" itemprop="email">swisschat@icloud.com</a><br>
-          Telefon/WhatsApp: <a href="tel:+41794067078" itemprop="telephone">+41 79 406 70 78</a></p>
+          <p>E‑Mail: <a href="mailto:swisschat@icloud.com" itemprop="email">swisschat@icloud.com</a></p>
         </div>
       </section>
 
@@ -93,7 +92,7 @@
 
       <section aria-labelledby="urheberrecht">
         <h2 id="urheberrecht"><span class="num" aria-hidden="true">4</span> Urheberrecht</h2>
-        <p>Inhalt, Design und Logos dieser Website sind urheberrechtlich geschützt. Eine Nutzung über den privaten Gebrauch hinaus bedarf unserer vorherigen Zustimmung.</p>
+        <p>Derzeit ist nichts geschützt oder eingetragen; ein entsprechender Schutz ist pending.</p>
       </section>
 
       <section aria-labelledby="recht">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SwissChat Assistant</title>
+  <title>SwissChat</title>
   <meta name="description" content="Dein WhatsApp KI-Assistent, gehostet in der Schweiz. Transkribiert Sprachnachrichten auch in Dialekt!" />
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -244,7 +244,7 @@
         </svg>
       </div>
       
-      <h1>SwissChat Assistant</h1>
+      <h1>SwissChat</h1>
       <p class="subtitle">Dein WhatsApp KI-Assistent, gehostet in der Schweiz</p>
       
       <a class="cta-button" href="https://wa.me/41794067078?text=JETZT%20ABSENDEN%20%F0%9F%91%89%20Hey%20SwissChat%2C%20ich%20m%C3%B6chte%20dich%20als%20smarten%20Assistenten%20f%C3%BCr%20Chat%2C%20Sprachnachrichten%20%26%20mehr%20nutzen%20%F0%9F%9A%80%0ASEND%20NOW%20%F0%9F%91%89%20Hey%20SwissChat%2C%20I%20want%20to%20use%20you%20as%20my%20smart%20assistant%20for%20chat%2C%20voice%20messages%20%26%20more%20%F0%9F%9A%80" target="_blank" rel="noopener">
@@ -268,7 +268,7 @@
             </svg>
           </div>
           <h3 class="feature-title">Sprachnachrichten</h3>
-          <p class="feature-desc">Leite mir Audios weiter – ich sende dir Kurzfassung und Transkript.</p>
+          <p class="feature-desc">Leite mir Sprachnachrichten weiter – ich sende dir Zusammenfassung und Transkript.</p>
         </div>
 
         <div class="feature-card">
@@ -278,7 +278,7 @@
             </svg>
           </div>
           <h3 class="feature-title">Fragen stellen</h3>
-          <p class="feature-desc">Schreib oder sprich deine Frage – ich recherchiere auch im Web.</p>
+          <p class="feature-desc">Schick mir direkt eine Sprachnachricht oder einen Chat mit deiner Frage – ich recherchiere auch im Web.</p>
         </div>
 
         <div class="feature-card">
@@ -304,12 +304,12 @@
 
     <div class="highlight">
   <h2>🤖 Dein persönlicher KI-Assistent</h2>
-  <p>Stelle Fragen per Chat oder beginne eine Sprachnachricht mit <strong>„Hey SwissChat“</strong>, um direkt Antworten zu erhalten. 
+  <p>Stelle Fragen per Chat oder Sprachnachricht, um direkt Antworten zu erhalten.
   Mit integrierter <strong>Websuche</strong> für schnelle Recherchen – alles basierend auf der innovativen <strong>KI-Technologie von AlpineAI</strong>.</p>
 </div>
 
     <div class="privacy-note">
-      <p><strong>Multilingual:</strong> Funktioniert in Deutsch, English, Français und Italiano</p>
+      <p><strong>Multilingual:</strong> Funktioniert in einer Vielzahl von Sprachen, optimiert für Deutsch, Englisch, Französisch und Italienisch – wurde sogar auf Romanisch getestet ;)</p>
       <div class="languages">
         <div>🇩🇪 "Hallo" - Sofort loslegen</div>
         <div>🇬🇧 "Hello" - Start chatting</div>
@@ -319,7 +319,7 @@
     </div>
 
       <div class="footer">
-        <p>© <span id="year"></span> SwissChat Assistant</p>
+        <p>© <span id="year"></span> SwissChat</p>
         <p>Kontakt: <a href="mailto:swisschat@icloud.com">swisschat@icloud.com</a> • <a href="datenschutz.html">Datenschutz</a> • <a href="agb.html">AGB</a> • <a href="impressum.html">Impressum</a></p>
       </div>
   </div>


### PR DESCRIPTION
## Summary
- Streamline landing page copy: update title, messaging about voice notes and Q&A, remove activation phrase, and broaden multilingual blurb.
- Expand privacy policy to cover text/audio/images, Brave Search API or Serper usage, long-term stats for deleted users, and AlpineAI-only processing.
- Clean up legal pages by dropping the phone number, noting pending protections, and clarifying prepaid credit terms and expiry.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aedd34998c8327a364ed5a41e93e6a