### PR TITLE
Add email PDF instruction page

### DIFF
--- a/email-pdf.html
+++ b/email-pdf.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How to send an E-Mail as a PDF to SwissChat – SwissChat</title>
+  <meta name="description" content="Kurze Anleitung: E-Mails als PDF an SwissChat weiterleiten." />
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="96x96" href="favicon-96x96.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-icon-180x180.png">
+  <style>
+    :root {
+      --bg: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+      --fg: #ffffff;
+      --muted: #fecaca;
+      --brand: #dc2626;
+      --brand-light: #ef4444;
+      --card: rgba(255, 255, 255, 0.1);
+      --card-border: rgba(255, 255, 255, 0.2);
+      --shadow: 0 25px 50px -12px rgba(220, 38, 38, 0.3);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; color: var(--fg); background: var(--bg); min-height: 100vh; line-height: 1.7; }
+    a { color: #fff; text-underline-offset: 2px; }
+    .container { max-width: 880px; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+    .header { display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem; }
+    .back-btn { display: inline-flex; align-items: center; gap: .5rem; background: var(--card); border: 1px solid var(--card-border); border-radius: 12px; padding: .75rem 1rem; color: var(--fg); text-decoration: none; font-weight: 500; backdrop-filter: blur(10px); transition: all .3s ease; }
+    .back-btn:hover { background: rgba(255,255,255,.15); transform: translateY(-1px); }
+    .back-btn svg { width: 16px; height: 16px; fill: currentColor; }
+    .logo { width: 48px; height: 48px; border-radius: 12px; background: rgba(255,255,255,.9); display: grid; place-items: center; margin-left: auto; }
+    .logo svg { width: 24px; height: 24px; }
+    .content { background: var(--card); border: 1px solid var(--card-border); border-radius: 20px; padding: 2.25rem; backdrop-filter: blur(10px); box-shadow: var(--shadow); }
+    h1 { font-size: clamp(1.75rem, 4vw, 2.5rem); font-weight: 800; margin-bottom: 1rem; background: linear-gradient(135deg, var(--fg), var(--muted)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; text-align:center; }
+    .steps { display: grid; gap: 2rem; margin-top: 1.5rem; }
+    .step { text-align: center; }
+    .step img { width: 100%; max-width: 320px; border-radius: 16px; box-shadow: var(--shadow); }
+    .step p { margin-top: .75rem; }
+    .footer { text-align: center; color: var(--muted); font-size: .9rem; margin-top: 1.5rem; opacity: .85; }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+  </style>
+</head>
+<body>
+  <a href="#main" class="sr-only">Zum Inhalt springen</a>
+  <div class="container">
+    <header class="header" role="banner">
+      <a href="index.html" class="back-btn" aria-label="Zurück zur Startseite">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 12H5m7-7l-7 7 7 7"/></svg>
+        Zurück
+      </a>
+      <div class="logo" aria-label="SwissChat">
+        <svg viewBox="0 0 100 100" role="img" aria-hidden="true">
+          <path d="M20 15 C20 10, 25 5, 35 5 L65 5 C75 5, 80 10, 80 15 L80 45 C80 50, 75 55, 65 55 L40 55 L25 65 L25 55 C20 55, 15 50, 15 45 Z" fill="#dc2626"/>
+          <rect x="30" y="35" width="4" height="8" rx="2" fill="white"/>
+          <rect x="38" y="25" width="4" height="28" rx="2" fill="white"/>
+          <rect x="46" y="20" width="4" height="38" rx="2" fill="white"/>
+          <rect x="54" y="25" width="4" height="28" rx="2" fill="white"/>
+          <rect x="62" y="35" width="4" height="8" rx="2" fill="white"/>
+        </svg>
+      </div>
+    </header>
+
+    <main id="main" class="content" role="main" aria-labelledby="title">
+      <h1 id="title">How to send an E-Mail as a PDF to SwissChat</h1>
+      <div class="steps">
+        <figure class="step">
+          <img src="static/pdf_email_1.png" alt="E-Mail weiterleiten">
+          <figcaption><p>Auf weiterleiten klicken.<br><span lang="en">Tap forward.</span></p></figcaption>
+        </figure>
+        <figure class="step">
+          <img src="static/pdf_email_2.png" alt="Drucken wählen">
+          <figcaption><p>Drucken auswählen.<br><span lang="en">Choose print.</span></p></figcaption>
+        </figure>
+        <figure class="step">
+          <img src="static/pdf_email_3.png" alt="Teilen">
+          <figcaption><p>Auf teilen klicken.<br><span lang="en">Tap share.</span></p></figcaption>
+        </figure>
+        <figure class="step">
+          <img src="static/pdf_email_4.png" alt="WhatsApp wählen">
+          <figcaption><p>WhatsApp auswählen.<br><span lang="en">Select WhatsApp.</span></p></figcaption>
+        </figure>
+        <figure class="step">
+          <img src="static/pdf_email_5.png" alt="An SwissChat schicken">
+          <figcaption><p>An SwissChat schicken.<br><span lang="en">Send to SwissChat.</span></p></figcaption>
+        </figure>
+      </div>
+    </main>
+
+    <footer class="footer" role="contentinfo">
+      <p>© <span id="year"></span> SwissChat</p>
+      <p><a href="datenschutz.html">Datenschutz</a> • <a href="agb.html">AGB</a> • <a href="impressum.html">Impressum</a></p>
+    </footer>
+  </div>
+  <script data-goatcounter="https://swisschat.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/email-pdf` page showing how to forward an email as PDF to SwissChat

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b950eac898832792a9ee703fa5238a